### PR TITLE
Fix: VSCodeのシェル統合利用時にstarshipを初期化すると無限ループする問題を修正

### DIFF
--- a/bashrc.sh
+++ b/bashrc.sh
@@ -6,7 +6,10 @@ test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew
 
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 
-if type starship &>/dev/null; then
+# VSCodeのシェル統合を利用中に再度`eval "$(starship init bash)"`を行うと、無限ループしてしまう
+# そのため`eval "$(starship init bash)"`の実行は一度だけにしたい
+# eval "$(starship init bash)" を実行すると環境変数STARSHIP_SHELLが定義されるので、それの有無から実行の可否を決める
+if type starship &>/dev/null && [[ ! -v STARSHIP_SHELL ]]; then
     eval "$(starship init bash)"
 fi
 

--- a/bashrc.sh
+++ b/bashrc.sh
@@ -8,8 +8,8 @@ test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew
 
 # VSCodeのシェル統合を利用中に再度`eval "$(starship init bash)"`を行うと、無限ループしてしまう
 # そのため`eval "$(starship init bash)"`の実行は一度だけにしたい
-# `eval "$(starship init bash)"` を実行すると環境変数STARSHIP_SHELLが定義されるので、それの有無から実行の可否を決める
-if type starship &>/dev/null && [[ ! -v STARSHIP_SHELL ]]; then
+# `eval "$(starship init bash)"` を実行すると環境変数STARSHIP_CMD_STATUSが定義されるので、それの有無から実行の可否を決める
+if type starship &>/dev/null && [[ ! -v STARSHIP_CMD_STATUS ]]; then
     eval "$(starship init bash)"
 fi
 

--- a/bashrc.sh
+++ b/bashrc.sh
@@ -8,7 +8,7 @@ test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew
 
 # VSCodeのシェル統合を利用中に再度`eval "$(starship init bash)"`を行うと、無限ループしてしまう
 # そのため`eval "$(starship init bash)"`の実行は一度だけにしたい
-# eval "$(starship init bash)" を実行すると環境変数STARSHIP_SHELLが定義されるので、それの有無から実行の可否を決める
+# `eval "$(starship init bash)"` を実行すると環境変数STARSHIP_SHELLが定義されるので、それの有無から実行の可否を決める
 if type starship &>/dev/null && [[ ! -v STARSHIP_SHELL ]]; then
     eval "$(starship init bash)"
 fi


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #28

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
`eval "$(starship init bash)"`の実行は一度だけにしたいため、`eval "$(starship init bash)"` を実行すると環境変数STARSHIP_SHELLが定義されるので、それの有無から実行の可否を決める
## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
なし
## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし