### PR TITLE
fix: dotfiles/bashrc.sh の追加確認処理の不具合を修正した

### DIFF
--- a/bashrc.sh
+++ b/bashrc.sh
@@ -77,8 +77,8 @@ if [[ -t 0 ]]; then # 標準入力が端末のときだけ実行する(scpなど
     stty start undef
 fi
 
-script_directory="$(dirname "$(realpath "${BASH_SOURCE:-0}")")"
+SCRIPT_DIRECTORY="$(dirname "$(realpath "${BASH_SOURCE:-0}")")"
 
-if [[ -r "${script_directory}/alias.sh" ]]; then
-    source "${script_directory}/alias.sh"
+if [[ -r "${SCRIPT_DIRECTORY}/alias.sh" ]]; then
+    source "${SCRIPT_DIRECTORY}/alias.sh"
 fi

--- a/install.sh
+++ b/install.sh
@@ -18,12 +18,12 @@ script_directory="$(dirname "$(realpath "${BASH_SOURCE:-0}")")"
 
 if [[ -r "${HOME}/.bashrc" ]]; then
 
-    if grep -q "[ -r \"/workspaces/dotfiles/bashrc.sh\" ] && source \"/workspaces/dotfiles/bashrc.sh\"" ${HOME}/.bashrc; then
+    if grep -qF "[[ -r \"${script_directory}/bashrc.sh\" ]] && source \"${script_directory}/bashrc.sh\"" "${HOME}/.bashrc"; then
         # 既にbashrcを読む処理が追加されているのでスキップ
         :
     else
         cat <<EOF >>${HOME}/.bashrc
-[ -r "${script_directory}/bashrc.sh" ] && source "${script_directory}/bashrc.sh"
+[[ -r "${script_directory}/bashrc.sh" ]] && source "${script_directory}/bashrc.sh"
 EOF
     fi
 


### PR DESCRIPTION
特定の環境でしか追加しない処理が動作しなかった(常に.bashrcに行を追加し続けていた)

## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #なし

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
タイトルの通り
## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
なし
## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし