### PR TITLE
update: CIの定期実行を設定した #30

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: Install applications
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * 5"
 
 jobs:
   install:


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #30

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
#30 の通り
毎週金曜日の18時(日本時間)に実行するようにした

理由は、週末の金曜日の退勤したかしていないかの時にGitHub Actionsを回して、もしFAILしたらその週末に対応…みたいな感じにしたかったから

時刻が間違っていても、気にしない
## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
なし
## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし