### PR TITLE
fix: bashrc.shの読むファイルをinputrc → .inputrc にした

### DIFF
--- a/bashrc.sh
+++ b/bashrc.sh
@@ -83,6 +83,6 @@ if [[ -r "${SCRIPT_DIRECTORY}/alias.sh" ]]; then
     source "${SCRIPT_DIRECTORY}/alias.sh"
 fi
 
-bind -f "${SCRIPT_DIRECTORY}/inputrc"
+bind -f "${SCRIPT_DIRECTORY}/.inputrc"
 
 export STARSHIP_CONFIG="${SCRIPT_DIRECTORY}/starship.toml"


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- なし

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
#45 で行った修正により、bashrc.shで読むファイルのパスが変更になったが、その変更をしていなかった そのことによるエラーを修正した

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
なし
## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし