### PR TITLE
update: Windowsで利用するアプリのエイリアスを設定した #71

### DIFF
--- a/alias.sh
+++ b/alias.sh
@@ -35,4 +35,11 @@ elif [ "${OSTYPE}" == "darwin" ]; then
     alias start='open'
 fi
 
+# WSL で実行中に Windows のコマンドを実行するための alias
+if uname -r | grep -qi microsoft; then
+    builtin alias explorer='/mnt/c/Windows/explorer.exe'
+    builtin alias clip='/mnt/c/Windows/System32/clip.exe'
+    builtin alias code='/mnt/c/Users/*/AppData/Local/Programs/Microsoft\ VS\ Code/bin/code'
+fi
+
 unset alias


### PR DESCRIPTION
WSLを利用しているときは、clip.exeを利用したい
しかしWSLはWindows側のファイルシステムを読み書きするとかなり遅くなる
そのためすべてのPATHを通したくないため、必要なアプリだけ実行できるようにしたい

## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #71

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
`explorer` と `clip` 、`code` のエイリアスを設定する

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
なし

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし