### PR TITLE
lessのバージョンによって設定したオプションが使えない問題を修正する

### DIFF
--- a/bashrc.d/environment.sh
+++ b/bashrc.d/environment.sh
@@ -61,7 +61,13 @@ export HISTFILE="${DOTFILES_DIRECTORY}/.bash_history"
 
 if type less &>/dev/null; then
     # batで内部的にlessを使うときにless部分の行番号を表示したくないので、--LINE-NUMBERSを指定しない(aliasで設定する)
-    export LESS='--RAW-CONTROL-CHARS --LONG-PROMPT --hilite-search --IGNORE-CASE --no-init --mouse --use-color'
+    export LESS='--RAW-CONTROL-CHARS --LONG-PROMPT --hilite-search --IGNORE-CASE --no-init'
+    if ! less --mouse |& grep -q "There is no mouse option"; then
+        LESS+=" --mouse"
+    fi
+    if ! less --use-color |& grep -q "There is no use-color option"; then
+        LESS+=" --use-color"
+    fi
 
     if type src-hilite-lesspipe.sh &>/dev/null; then
         export LESSOPEN='|src-hilite-lesspipe.sh %s'


### PR DESCRIPTION
## Issue

<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->

- #xx

## 対応内容

<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
--mouseオプションが使えないバージョンをつかうと、less起動時にいちいち--mouseが使えないと出てくる

そのため、--mouseや--use-colorなどに対応しているときは使うように設定する

## テスト

<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->

## 残作業

<!--
  このPRでは解決していない内容について説明。
-->
