### PR TITLE
fix: bashrc.shの起動が遅くなる不具合とcargo補完まわりのエラーを修正

### DIFF
--- a/bashrc.sh
+++ b/bashrc.sh
@@ -23,19 +23,10 @@ if type nix &>/dev/null; then
     if [[ -r ~/.nix-profile/etc/profile.d/bash_completion.sh ]]; then
         source ~/.nix-profile/etc/profile.d/bash_completion.sh
     fi
-
-    for COMPLETION in ~/.nix-profile/share/bash-completion/completions/*; do
-        [[ -r "${COMPLETION}" ]] && source "${COMPLETION}"
-    done
-    unset COMPLETION
 fi
 
 if type fzf &>/dev/null; then
     eval "$(fzf --bash)"
-fi
-
-if type rustc &>/dev/null; then
-    source "$(rustc --print sysroot)/etc/bash_completion.d/cargo"
 fi
 
 if type git &>/dev/null; then


### PR DESCRIPTION
## Summary
- Homebrew→Nix移行(#147)で、`~/.nix-profile/share/bash-completion/completions/`配下の全ファイル(1000個超)を起動時に無条件でsourceするようになっており、これが起動を大幅に遅くしていた
- これらのファイルは本来Nixのbash-completionフレームワーク(既に読み込み済み)がコマンド補完時に遅延読み込みする前提のもので、直接sourceすると`_cargo`のトップレベル`local`がエラーになる(`local: can only be used in a function`)
- rustc経由のcargo補完手動読み込みも同様にフレームワークに任せられ、かつrustupのデフォルトツールチェイン未設定時に`rustup could not choose a version of rustc to run...`や`No such file or directory`エラーの原因になっていたため、両方削除した

## Test plan
- [x] `bash -ic 'echo done'`で起動時間が(タイムアウトするほど遅かった状態から)約0.2秒に短縮されたことを確認
- [x] `local: can only be used in a function`エラーが出なくなったことを確認
- [x] rustup関連のエラーが出なくなったことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)