### PR TITLE
feat: flake.lockをコミットしてnixpkgsのバージョンを固定する

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782978903,
+        "narHash": "sha256-bG1LAS3YehMzp4RSXw99o3yMEO/Ktb0Tx29RCtEU0Tk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d33369954a67ae3322177dc9a3d564092912120c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
## Summary
- flake.lock がこれまでコミットされておらず、`install.sh` 実行のたびに nixpkgs-unstable の最新コミットを解決し直すため環境の再現性が失われていた
- flake.lock をコミットして nixpkgs のバージョンを固定する

## Test plan
- [x] `./install.sh` を実行してエラーなく完了することを確認