### PR TITLE
docs: 修正作業のフローとcspellチェックの実施をCLAUDE.mdに明記する

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -157,6 +157,7 @@
     "vmap",
     "wildmode",
     "workalike",
+    "worktree",
     "wrapscan",
     "xclip",
     "xz",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ./uninstall.sh  # Nix・導入したパッケージ・~/.bashrcのフックを削除する
 ```
 
+## 作業フロー
+
+バグ修正・機能追加・ドキュメント修正を問わず、変更作業は `git worktree` で作業ディレクトリを
+分離してから行い、完了したら `main` に直接コミットせず PR を作成すること。`main` を常にクリーンな
+状態に保つため。
+
+コミットする前には必ず `npx cspell .` を実行し、指摘があれば解消してからコミットすること。
+cspellのチェックにはよく引っかかるため。
+
 Lint(GitHub ActionsのFormat/Spellワークフローと同じもの):
 
 ```bash


### PR DESCRIPTION
## Summary
- 修正作業(バグ修正・機能追加・ドキュメント修正すべて)はgit worktreeで分離し、完了後はmainへ直接コミットせずPRを作成する運用をCLAUDE.mdに明記
- cspellのチェックによく引っかかるため、コミット前に必ず`npx cspell .`を実行する運用も明記
- 併せて、今回新たに使った"worktree"を.cspell.jsonの辞書に追加

## Test plan
- [x] `nix run nixpkgs#cspell -- .` で0件になることを確認