### PR TITLE
feat: zellijの操作感を再現するtmux設定を追加する

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -100,6 +100,7 @@
     "nmap",
     "nnoremap",
     "nobackup",
+    "nobold",
     "nocompatible",
     "nofilter",
     "nohlsearch",

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,0 +1,212 @@
+# zellijの操作感をtmuxで再現する
+# 参考: https://github.com/zellij-org/zellij/blob/main/zellij-utils/assets/config/default.kdl
+#
+# 通常のprefix(デフォルト C-b)はそのまま残し、
+# zellijの各モード(pane/tab/resize/move/scroll/session)に相当するkey tableを
+# 独立したprefixとして追加する
+# 参考: `bind-key -n` はキーをprefix無しのroot tableに束縛する(man tmuxのbind-key参照)
+#
+# zellijは一度モードに入ると、Enter/Esc/そのモードの起動キー自身を再度押すまで
+# ずっとそのモードに留まり続ける(shared_except "normal" "locked"のEnter/Esc束縛、
+# および各モード自身のCtrl+キー束縛)。tmuxのkey tableはデフォルトでは1回キーを
+# 処理すると即座にrootに戻る(`-r`を付けてもrepeat-time経過で戻る)ため、
+# 移動系のキーは末尾で`switch-client -T <table>`を呼び直すことで同じモードに
+# 留まり続けるようにしている。一方、ペイン生成・削除などの単発アクションは
+# zellij本家でも実行後に`SwitchToMode "Normal"`しているため、tmux側も何もせず
+# rootに戻る(=chainしない)デフォルト挙動のままでよい。
+
+# マウス対応(ペイン選択・リサイズ・ウィンドウ切り替え・スクロール)
+set -g mouse on
+
+# ---------------------------------------------------------------
+# 各モードへの入口(zellijのshared_exceptブロック相当)
+# ---------------------------------------------------------------
+bind-key -n C-p switch-client -T pane-mode
+bind-key -n C-t switch-client -T tab-mode
+bind-key -n C-n switch-client -T resize-mode
+bind-key -n C-h switch-client -T move-mode
+# zellijのscroll/searchモードは、tmux標準のcopy-mode(検索・ページスクロール等を内蔵)で代用する
+bind-key -n C-s copy-mode
+bind-key -n C-o switch-client -T session-mode
+
+# ---------------------------------------------------------------
+# copy-mode(選択・コピー)の分かりやすさ改善
+# ---------------------------------------------------------------
+# tmuxのvi風copy-modeはデフォルトのままだと素のvimの直感と食い違う
+# (vが選択開始ではなく矩形選択トグル、yはどこにも束縛されていない)。
+# 実際のvimの v/V/C-v (文字/行/矩形選択) に揃え直す。
+set -g mode-keys vi
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+# V(行選択)とC-v(矩形選択トグル)はtmuxの元のデフォルトのままなので上書き不要
+
+# コピーした選択範囲をOS標準のクリップボードに送る(pbcopy/xclip/wl-copyの
+# 順に存在するものを使い、どれも無ければ何もしない=各種コマンドが無い環境でも
+# エラーで落ちないようにする)。tmux組み込みのset-clipboard(OSC 52)によるコピーとは
+# 別経路で、対応していない端末でも確実に届くようにする。
+set -g @copy_command "if command -v pbcopy >/dev/null 2>&1; then pbcopy; elif command -v xclip >/dev/null 2>&1; then xclip -selection clipboard -in; elif command -v wl-copy >/dev/null 2>&1; then wl-copy; else cat >/dev/null; fi"
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "#{@copy_command}"
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "#{@copy_command}"
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_command}"
+# zellijのCtrl+Qは確認無しで即終了するが、tmuxはサーバーごと落ちて影響が大きいため確認を挟む
+bind-key -n C-q confirm-before -p "kill-server? (y/n)" kill-server
+
+# zellijのshared_exceptブロックにある、モードに入らず直接使える一般ショートカット
+# (h/j/k/lと矢印キーはzellij本家でも常にペアで束縛されているため両方登録する)
+# zellijのNewPane(方向指定無し)はペインの縦横比を見て分割方向を自動で決めるため、
+# 幅>=高さ(文字セル数)なら左右分割、そうでなければ上下分割にすることで近似する
+bind-key -n M-n if-shell -F "#{e|>=:#{pane_width},#{pane_height}}" "split-window -h" "split-window -v"
+bind-key -n M-h select-pane -L
+bind-key -n M-Left select-pane -L
+bind-key -n M-l select-pane -R
+bind-key -n M-Right select-pane -R
+bind-key -n M-j select-pane -D
+bind-key -n M-Down select-pane -D
+bind-key -n M-k select-pane -U
+bind-key -n M-Up select-pane -U
+bind-key -n M-i swap-window -t -1
+bind-key -n M-o swap-window -t +1
+bind-key -n M-] next-layout
+bind-key -n M-[ previous-layout
+# zellijのFloating Pane相当。tmuxにはフローティングペインという概念自体は無いが、
+# display-popup(既存のペイン配置の上に矩形を重ねて表示し、閉じても配置に影響しない)が
+# 近い挙動を提供するため代用する。man tmuxにはEscape/Ctrl+cでも閉じられると書かれて
+# いるが、popup内で対話シェルを動かす今回の使い方では実際には反応しなかった(検証済み)。
+# 確実に閉じる方法は`exit`でシェルを終了すること(-Eにより自動でポップアップも閉じる)。
+bind-key -n M-f display-popup -E -d "#{pane_current_path}" -w 80% -h 80% -T "floating"
+
+# ---------------------------------------------------------------
+# pane-mode: ペイン操作 (Ctrl+P)
+# ---------------------------------------------------------------
+# 移動系はモードに留まり続ける(zellij本家もh/l/j/k/pはSwitchToMode Normalしない)
+# h/j/k/lと矢印キーはzellij本家でも常にペアで束縛されている
+bind-key -T pane-mode h select-pane -L \; switch-client -T pane-mode
+bind-key -T pane-mode Left select-pane -L \; switch-client -T pane-mode
+bind-key -T pane-mode l select-pane -R \; switch-client -T pane-mode
+bind-key -T pane-mode Right select-pane -R \; switch-client -T pane-mode
+bind-key -T pane-mode j select-pane -D \; switch-client -T pane-mode
+bind-key -T pane-mode Down select-pane -D \; switch-client -T pane-mode
+bind-key -T pane-mode k select-pane -U \; switch-client -T pane-mode
+bind-key -T pane-mode Up select-pane -U \; switch-client -T pane-mode
+bind-key -T pane-mode p select-pane -t :.+ \; switch-client -T pane-mode
+# 生成・削除系は1回実行したらNormal相当(root)に戻る(zellij本家と同じ)
+# nは方向指定無しのNewPane相当なので、M-nと同じ自動判定分割にする
+bind-key -T pane-mode n if-shell -F "#{e|>=:#{pane_width},#{pane_height}}" "split-window -h" "split-window -v"
+bind-key -T pane-mode d split-window -v
+bind-key -T pane-mode r split-window -h
+bind-key -T pane-mode x kill-pane
+bind-key -T pane-mode f resize-pane -Z
+bind-key -T pane-mode c command-prompt -I "#T" "select-pane -T '%%'"
+# モードの明示的な終了(zellijのCtrl+p再押下、Enter/Esc相当)
+bind-key -T pane-mode C-p switch-client -T root
+bind-key -T pane-mode Enter switch-client -T root
+bind-key -T pane-mode Escape switch-client -T root
+
+# ---------------------------------------------------------------
+# tab-mode: タブ(window)操作 (Ctrl+T)
+# ---------------------------------------------------------------
+# zellij本家: n=新規 x=閉じる h/k(および矢印Left/Up)=前へ l/j(および矢印Right/Down)=次へ r=リネーム 1-9=直接選択
+bind-key -T tab-mode h select-window -t :- \; switch-client -T tab-mode
+bind-key -T tab-mode k select-window -t :- \; switch-client -T tab-mode
+bind-key -T tab-mode Left select-window -t :- \; switch-client -T tab-mode
+bind-key -T tab-mode Up select-window -t :- \; switch-client -T tab-mode
+bind-key -T tab-mode l select-window -t :+ \; switch-client -T tab-mode
+bind-key -T tab-mode j select-window -t :+ \; switch-client -T tab-mode
+bind-key -T tab-mode Right select-window -t :+ \; switch-client -T tab-mode
+bind-key -T tab-mode Down select-window -t :+ \; switch-client -T tab-mode
+bind-key -T tab-mode n new-window
+bind-key -T tab-mode x kill-window
+bind-key -T tab-mode r command-prompt -I "#W" "rename-window '%%'"
+bind-key -T tab-mode 1 select-window -t 1
+bind-key -T tab-mode 2 select-window -t 2
+bind-key -T tab-mode 3 select-window -t 3
+bind-key -T tab-mode 4 select-window -t 4
+bind-key -T tab-mode 5 select-window -t 5
+bind-key -T tab-mode 6 select-window -t 6
+bind-key -T tab-mode 7 select-window -t 7
+bind-key -T tab-mode 8 select-window -t 8
+bind-key -T tab-mode 9 select-window -t 9
+bind-key -T tab-mode C-t switch-client -T root
+bind-key -T tab-mode Enter switch-client -T root
+bind-key -T tab-mode Escape switch-client -T root
+
+# ---------------------------------------------------------------
+# resize-mode: ペインのリサイズ (Ctrl+N)
+# ---------------------------------------------------------------
+# zellij本家はh/j/k/l=拡大、H/J/K/L=縮小と別キーだが、tmuxのresize-paneは
+# 隣接ペインの有無で挙動が変わり縮小方向を安定して再現できないため、
+# 拡大方向のみをh/j/k/lに割り当てる簡略化とする(意図的な省略)
+bind-key -T resize-mode h resize-pane -L 5 \; switch-client -T resize-mode
+bind-key -T resize-mode Left resize-pane -L 5 \; switch-client -T resize-mode
+bind-key -T resize-mode j resize-pane -D 5 \; switch-client -T resize-mode
+bind-key -T resize-mode Down resize-pane -D 5 \; switch-client -T resize-mode
+bind-key -T resize-mode k resize-pane -U 5 \; switch-client -T resize-mode
+bind-key -T resize-mode Up resize-pane -U 5 \; switch-client -T resize-mode
+bind-key -T resize-mode l resize-pane -R 5 \; switch-client -T resize-mode
+bind-key -T resize-mode Right resize-pane -R 5 \; switch-client -T resize-mode
+bind-key -T resize-mode C-n switch-client -T root
+bind-key -T resize-mode Enter switch-client -T root
+bind-key -T resize-mode Escape switch-client -T root
+
+# ---------------------------------------------------------------
+# move-mode: ペインの移動 (Ctrl+H)
+# ---------------------------------------------------------------
+bind-key -T move-mode h swap-pane -s '{left-of}' \; switch-client -T move-mode
+bind-key -T move-mode Left swap-pane -s '{left-of}' \; switch-client -T move-mode
+bind-key -T move-mode l swap-pane -s '{right-of}' \; switch-client -T move-mode
+bind-key -T move-mode Right swap-pane -s '{right-of}' \; switch-client -T move-mode
+bind-key -T move-mode j swap-pane -s '{down-of}' \; switch-client -T move-mode
+bind-key -T move-mode Down swap-pane -s '{down-of}' \; switch-client -T move-mode
+bind-key -T move-mode k swap-pane -s '{up-of}' \; switch-client -T move-mode
+bind-key -T move-mode Up swap-pane -s '{up-of}' \; switch-client -T move-mode
+bind-key -T move-mode n swap-pane -t :.+ \; switch-client -T move-mode
+bind-key -T move-mode p swap-pane -t :.- \; switch-client -T move-mode
+bind-key -T move-mode C-h switch-client -T root
+bind-key -T move-mode Enter switch-client -T root
+bind-key -T move-mode Escape switch-client -T root
+
+# ---------------------------------------------------------------
+# session-mode: セッション操作 (Ctrl+O)
+# ---------------------------------------------------------------
+# zellij本家のc/p/a/s/lはプラグインUI(configuration/plugin-manager/about/share/
+# layout-manager)を開くものでtmuxに対応物が無いため、それらのキーとは衝突しない
+# n/x/rに実用上必要な新規作成・削除・リネームを割り当てる(意図的な代替)
+bind-key -T session-mode d detach-client
+bind-key -T session-mode w choose-tree -Zs
+bind-key -T session-mode n new-session
+bind-key -T session-mode x kill-session
+bind-key -T session-mode r command-prompt -I "#S" "rename-session '%%'"
+bind-key -T session-mode C-o switch-client -T root
+bind-key -T session-mode Enter switch-client -T root
+bind-key -T session-mode Escape switch-client -T root
+
+# ---------------------------------------------------------------
+# 画面構成をzellijに寄せる
+#   上部1行 = タブバー   : セッション名 + タブ(window)一覧(zellijのtab-bar相当)
+#   下部1行 = ステータスバー: 現在のモード名 + そのモードで使えるショートカット一覧
+#                            (zellijのstatus-bar相当。key tableに追従して表示が変わる)
+# zellijのデフォルトレイアウト(tab-bar=上/status-bar=下、各1行)をそのまま再現する。
+# tmuxのstatus-lineは画面の片側にしか置けないため、
+#   ・下部のモードバー   → status-line(status-position bottom)で描画
+#   ・上部のタブバー     → ペイン上辺のボーダー行(pane-border-status top)に描画
+# という2つの仕組みを併用して上下に振り分けている。
+# ---------------------------------------------------------------
+
+# --- 上部: タブバー(セッション名 + タブ一覧) ---
+# 画面最上段のペイン(pane_top==1 かつ pane_left==0 の左上ペイン)のボーダー行にだけ
+# タブバーを描画し、それ以外のペインのボーダーにはペイン番号とコマンド名を出す
+# (分割時は各ペインの枠がzellijのペインフレームのように機能する)。
+# #{W:A,B} はウィンドウ毎にAを、カレントウィンドウにはBを適用する
+# (display-messageでは展開されないがステータス/ボーダー描画時には展開される)。
+set -g pane-border-status top
+set -g pane-border-format "#{?#{&&:#{==:#{pane_top},1},#{==:#{pane_left},0}},#[fg=black bg=green] #S #[default] #{W:#[fg=default] #I #W ,#[fg=black bg=green] #I #W #[default]},#[fg=default] #{pane_index} #{pane_current_command} }"
+
+# --- 下部: モードバー(モード名 + ショートカット一覧) ---
+# tmux組み込みのstatus-styleのデフォルトは bg=green,fg=black になっており、
+# 各モードのヒント文字列内で使っている"bg=default"はこのグローバルなstatus-styleの
+# 色を指す(端末の素の背景色ではない)。明示的にリセットしておかないと、
+# NORMALモードのヒント文字(fg=green)が緑背景に重なって見えなくなる。
+set -g status-style "fg=default bg=default"
+set -g status-position bottom
+set -g status on
+set -g status-interval 60
+set -g status-format[0] "#[align=left]#{?#{pane_in_mode},#[fg=black bg=white] COPY #[fg=white bg=default nobold] <v> Select  <V> Line  <C-v> Block  <y/Enter> Copy  </> Search  <q/Esc> Exit,#{?#{==:#{client_key_table},pane-mode},#[fg=black bg=blue] PANE #[fg=blue bg=default nobold] <h/j/k/l> Focus  <n/d/r> New  <x> Kill  <f> Zoom  <c> Rename  <Enter/Esc> Exit,#{?#{==:#{client_key_table},tab-mode},#[fg=black bg=cyan] TAB #[fg=cyan bg=default nobold] <h/k> Prev  <l/j> Next  <n> New  <x> Kill  <r> Rename  <1-9> Select  <Enter/Esc> Exit,#{?#{==:#{client_key_table},resize-mode},#[fg=black bg=magenta] RESIZE #[fg=magenta bg=default nobold] <h/j/k/l> Resize  <Enter/Esc> Exit,#{?#{==:#{client_key_table},move-mode},#[fg=black bg=yellow] MOVE #[fg=yellow bg=default nobold] <h/j/k/l> Swap  <n/p> Cycle  <Enter/Esc> Exit,#{?#{==:#{client_key_table},session-mode},#[fg=black bg=red] SESSION #[fg=red bg=default nobold] <n> New  <x> Kill  <d> Detach  <w> Switch  <r> Rename  <Enter/Esc> Exit,#[fg=green bg=default nobold]Ctrl + #[bold]<p>#[nobold] PANE  #[bold]<t>#[nobold] TAB  #[bold]<n>#[nobold] RESIZE  #[bold]<h>#[nobold] MOVE  #[bold]<s>#[nobold] SEARCH  #[bold]<o>#[nobold] SESSION  #[bold]<q>#[nobold] QUIT#[align=right]Alt + #[bold]<n>#[nobold] New Pane  #[bold]<f>#[nobold] Floating}}}}}}"


### PR DESCRIPTION
## Summary
- zellijのキー割り当て(pane/tab/resize/move/session各モード)・マウス対応・タブバー/ステータスバー・copy-modeの分かりやすさ改善を再現した `tmux/tmux.conf` を新規追加

## Test plan
- [x] `nix run nixpkgs#tmux -- -f tmux/tmux.conf new-session` で構文エラーが無いことを確認
- [x] pty+pyte で実際の画面描画(タブバー・ステータスバー・各モードバッジの配色)を検証
- [x] ユーザー自身がアタッチして動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)