### PR TITLE
fix: tmuxをNixで導入し、独自設定を読み込むエイリアスを追加する

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -164,6 +164,7 @@
     "xz",
     "yuto",
     "yutotnh",
+    "zellij",
     "zoxide",
     "zshrc"
   ],

--- a/bashrc.d/aliases.sh
+++ b/bashrc.d/aliases.sh
@@ -36,6 +36,7 @@ alias mv='mv -i'
 alias nkf='nkf -x'
 alias sl='ls'
 alias ssh='ssh -XC'
+alias tmux='tmux -f "${DOTFILES_DIRECTORY}/tmux/tmux.conf"'
 alias view='vim -RM'
 
 if [ "${OSTYPE}" == "linux-gnu" ]; then

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
               rustup
               sourceHighlight
               starship
+              tmux
               vim
               zoxide
             ]


### PR DESCRIPTION
## Summary
- PR #151 で `tmux/tmux.conf` を追加したが、`tmux` コマンド自体を Nix で導入する設定と、独自設定ファイルを読み込むエイリアスの追加が漏れていたため追加
- cspell の辞書に `zellij` を追加(未登録でチェックに引っかかっていたため)

## Test plan
- [x] `npx prettier --check "**/*.{json,md,yml}"`
- [x] `npx cspell .`
- [x] `shellcheck --exclude=SC1090,SC1091,SC2046 *.sh bashrc.d/*.sh`
- [x] `source bashrc.sh` 後に `alias tmux` で意図通りのエイリアスが定義されることを確認