### PR TITLE
feat: エージェント多重化ツールherdrとMarkdown Viewerのglowを追加する

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -67,6 +67,7 @@
     "guicursor",
     "guix",
     "haxe",
+    "herdr",
     "hilite",
     "hlsearch",
     "icdiff",

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,6 @@
               git
               gitui
               glow
-              herdr
               icdiff
               jq
               less
@@ -49,6 +48,7 @@
             ]
             ++ lib.optionals stdenv.isLinux [
               glibcLocales
+              herdr
               xclip
             ];
           extraOutputsToInstall = [

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
               gh
               git
               gitui
+              glow
+              herdr
               icdiff
               jq
               less


### PR DESCRIPTION
## Summary
- Markdown ビューア glow を Nix 管理下に追加(全プラットフォーム対応)
- エージェント多重化ツール herdr (herdr.dev) を Nix 管理下に追加。ただし herdr は nixpkgs 上で Darwin 向けバイナリキャッシュが無く、CI 環境でのソースビルドが vendored 依存 (`libghostty-vt`, zig) の `DarwinSdkNotFound` で失敗するため、Linux 限定 (`lib.optionals stdenv.isLinux`) で追加する
- 両ツールとも pin 済みの nixpkgs (flake.lock) に存在するため flake.lock の更新は不要

## Test plan
- [x] `npx cspell .` が通ることを確認 (herdr を辞書に追加)
- [x] `npx prettier --check "**/*.{json,md,yml}"` (既存の `.claude/settings.local.json` 警告は本変更と無関係、gitignore 対象)
- [x] `shellcheck` (nix run 経由) で問題なし
- [x] `nix flake check` が通ることを確認
- [x] `nix build .#default` (x86_64-linux) でビルドでき、`glow --version` / `herdr --version` が動作することを確認
- [x] `nix eval` で x86_64-darwin の paths に herdr が含まれず、x86_64-linux には含まれることを確認
- [ ] CI (install-macos 含む全ジョブ) の green を確認してからマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)