### PR TITLE
Set PAGER environment variable to less

### DIFF
--- a/bashrc.d/environment.sh
+++ b/bashrc.d/environment.sh
@@ -60,6 +60,8 @@ export HISTCONTROL=ignoreboth
 export HISTFILE="${DOTFILES_DIRECTORY}/.bash_history"
 
 if type less &>/dev/null; then
+    export PAGER="less"
+
     # batで内部的にlessを使うときにless部分の行番号を表示したくないので、--LINE-NUMBERSを指定しない(aliasで設定する)
     export LESS='--RAW-CONTROL-CHARS --LONG-PROMPT --hilite-search --IGNORE-CASE --no-init'
     if less --help |& grep -q -- "--mouse"; then


### PR DESCRIPTION
## Issue

- N/A

## 対応内容

`bashrc.d/environment.sh` で `less` コマンドが利用可能な場合に、`PAGER` 環境変数を明示的に `less` に設定するようにしました。

これにより、ページャーが必要な場面で `less` が確実に使用されるようになります。既存の `LESS` 環境変数の設定と合わせて、`less` の動作をより確実に制御できます。

## テスト

N/A

## 残作業

なし

https://claude.ai/code/session_016jtAU4Gow9XNSV4bbBiD9K