### PR TITLE
refactor: .vimrc/.vim/をvim/ディレクトリへ移動する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .bash_history
-.vim/
+vim/local/
 git/.gitconfig.local

--- a/bashrc.d/environment.sh
+++ b/bashrc.d/environment.sh
@@ -163,7 +163,7 @@ if type fzf &>/dev/null; then
 fi
 
 if type vim &>/dev/null; then
-    export MYVIMRC="${DOTFILES_DIRECTORY}/.vimrc"
+    export MYVIMRC="${DOTFILES_DIRECTORY}/vim/vimrc"
     export VIMINIT="source ${MYVIMRC}"
 fi
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -132,18 +132,18 @@ nmap <Esc><Esc> :nohlsearch<CR><Esc>
 " DOTFILES_DIRECTORY の中でプラグインを管理するようにする
 if exists('$DOTFILES_DIRECTORY')
     " DOTFILESが設定されている場合の処理
-    if empty(glob('$DOTFILES_DIRECTORY/.vim/autoload/plug.vim'))
-        silent !curl -fLo "$DOTFILES_DIRECTORY/.vim/autoload/plug.vim" --create-dirs  https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+    if empty(glob('$DOTFILES_DIRECTORY/vim/local/autoload/plug.vim'))
+        silent !curl -fLo "$DOTFILES_DIRECTORY/vim/local/autoload/plug.vim" --create-dirs  https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
     endif
 
-    set runtimepath+=$DOTFILES_DIRECTORY/.vim
+    set runtimepath+=$DOTFILES_DIRECTORY/vim/local
 
     " Run PlugInstall if there are missing plugins
     autocmd VimEnter * if len(filter(values(g:plugs), '!isdirectory(v:val.dir)'))
         \| PlugInstall --sync | source $MYVIMRC
     \| endif
 
-    call plug#begin('$DOTFILES_DIRECTORY/.vim/plugged')
+    call plug#begin('$DOTFILES_DIRECTORY/vim/local/plugged')
         Plug 'tpope/vim-fugitive'
         Plug 'airblade/vim-gitgutter'
         Plug 'prabirshrestha/vim-lsp'
@@ -157,7 +157,7 @@ if exists('$DOTFILES_DIRECTORY')
         Plug 'ojroques/vim-oscyank', {'branch': 'main'}
     call plug#end()
 
-    let g:lsp_settings_servers_dir = $DOTFILES_DIRECTORY . '/.vim/vim-lsp-settings/servers'
+    let g:lsp_settings_servers_dir = $DOTFILES_DIRECTORY . '/vim/local/vim-lsp-settings/servers'
 
     let g:airline#extensions#tabline#enabled = 1
     let g:airline_powerline_fonts = 1


### PR DESCRIPTION
## Summary
- ルート直下の `.vimrc` を `vim/vimrc` へ移動
- vim-plugが自動生成するランタイムデータ(`autoload/plug.vim`・`plugged/`・`vim-lsp-settings/`)は `.vim/` から `vim/local/` へ移動。自分で書いた `vimrc` と生成物を区別するため、`vim/` 直下ではなく `vim/local/` にまとめた(git/やnix/と同様にツールごとにディレクトリへ集約する流れ)
- `.gitignore` の `.vim/` を `vim/local/` に変更
- `bashrc.d/environment.sh` の `MYVIMRC` を新しいパスに変更

## Test plan
- [x] `.vim`/`.vimrc` への参照が他に残っていないことを確認(grep)
- [x] `npx prettier --check "**/*.{json,md,yml}"`
- [x] `npx cspell .`
- [x] `nix run nixpkgs#shellcheck -- --exclude=SC1090,SC1091,SC2046 *.sh bashrc.d/*.sh` (exit 0)
- [x] CI の install → update → uninstall ライフサイクル検証(Rocky Linux 9 / Ubuntu / macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)