### PR TITLE
Add OSC 52-based clip function for remote clipboard access

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -117,6 +117,7 @@
     "prabirshrestha",
     "preservim",
     "procps",
+    "Ptmux",
     "pulumi",
     "purescript",
     "pyenv",

--- a/bashrc.d/aliases.sh
+++ b/bashrc.d/aliases.sh
@@ -47,9 +47,11 @@ elif [[ "${OSTYPE}" == *"darwin"* ]]; then
 fi
 
 # WSL で実行中に Windows のコマンドを実行するための alias
+# clip.exe は WSLのホスト自体のクリップボードにコピーするため、SSH等で別マシンから
+# 接続している場合は接続元に届かない。そのため clip はOSC 52ベースの関数(functions.sh)に
+# 統一し、ここではエイリアスとして登録しない
 if uname -r | grep -qi microsoft; then
     builtin alias explorer='/mnt/c/Windows/explorer.exe'
-    builtin alias clip='/mnt/c/Windows/System32/clip.exe'
     builtin alias code='/mnt/c/Users/*/AppData/Local/Programs/Microsoft\ VS\ Code/bin/code'
 fi
 

--- a/bashrc.d/functions.sh
+++ b/bashrc.d/functions.sh
@@ -56,6 +56,35 @@ function cd-foolish() {
 }
 
 #
+# @brief OSC 52 escape sequenceを使って標準入力をクリップボードにコピーする
+#
+# ローカルにクリップボード操作コマンド(xclip/wl-copy/pbcopy等)が無い環境や、
+# SSHで接続している場合(WSLの`clip.exe`のようにサーバー側のクリップボードにコピーする
+# 手段では、接続元のクリップボードに届かない)でも、OSC 52に対応した端末であれば
+# 接続元のクリップボードにコピーできる
+#
+# 例:
+# $ echo -n "hello" | clip
+function clip() {
+    if ! type base64 &>/dev/null; then
+        echo "clip: base64 command not found" >&2
+        return 1
+    fi
+
+    local data
+    data=$(base64 | tr -d '\n')
+
+    if [ -n "${TMUX:-}" ]; then
+        # tmux配下だとOSC 52がtmux自身に消費されてしまうため、DCSでパススルーする
+        # 参考: https://github.com/tmux/tmux/wiki/Clipboard
+        # shellcheck disable=SC1003 # 末尾の\\は printf に渡すエスケープシーケンス(ST)の一部であり、シングルクォートのエスケープではない
+        printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "${data}" >/dev/tty
+    else
+        printf '\033]52;c;%s\a' "${data}" >/dev/tty
+    fi
+}
+
+#
 # @brief カレントディレクトリ以下の今日以前で最も今日に近いISO 8601の日付形式のディレクトリ名を返す
 #
 # 例1: 今日の日付のディレクトリがない場合


### PR DESCRIPTION
## 対応内容

OSC 52エスケープシーケンスを使用してクリップボード操作を行う `clip` 関数を追加しました。

### 背景

従来のWSL環境では `clip.exe` を使用していましたが、SSH経由で接続している場合、`clip.exe` はサーバー側のクリップボードにコピーするため、接続元マシンのクリップボードに届きません。

### 変更内容

1. **新規関数 `clip()`** (`bashrc.d/functions.sh`)
   - OSC 52エスケープシーケンスを使用して標準入力をクリップボードにコピー
   - ローカルコマンド(xclip/wl-copy/pbcopy等)がない環境でも動作
   - SSH接続時に接続元のクリップボードにコピー可能
   - tmux配下での動作に対応（DCSパススルーを使用）
   - base64コマンドの存在確認を実施

2. **aliases.sh の修正**
   - WSL環境での `clip` エイリアスを削除
   - 代わりに `functions.sh` の `clip` 関数を使用するよう統一
   - コメントで理由を明記

3. **cspell設定の更新**
   - `Ptmux` を許可リストに追加（tmuxのDCSシーケンス用語）

## テスト

- CI(GitHub Actions)で `npx cspell .` が通過することを確認
- 既存の graceful-degradation 設計に従い、base64コマンドがない環境でもエラーハンドリング済み
- tmux配下での動作確認用コメント・参考リンク付き

## 残作業

なし

https://claude.ai/code/session_011zgVzz6Ut5oEAHugioW9X7