### PR TITLE
feat: glowをページャー表示にする設定をdotfilesで管理する

### DIFF
--- a/bashrc.d/environment.sh
+++ b/bashrc.d/environment.sh
@@ -177,6 +177,13 @@ if type git &>/dev/null; then
     export GIT_CONFIG_GLOBAL="${DOTFILES_DIRECTORY}/git/.gitconfig"
 fi
 
+if type glow &>/dev/null; then
+    # glow は GLOW_CONFIG_HOME 直下(サブディレクトリ無し)の glow.yml を設定ファイルとして参照する
+    # (XDG_CONFIG_HOME と違い glow サブディレクトリは付かない)
+    # ページャー表示(pager: true)などの設定を dotfiles 内で管理するために参照させている
+    export GLOW_CONFIG_HOME="${DOTFILES_DIRECTORY}/glow"
+fi
+
 if type gpg &>/dev/null; then
     GPG_TTY=$(tty)
     export GPG_TTY

--- a/glow/glow.yml
+++ b/glow/glow.yml
@@ -1,0 +1,13 @@
+# glow の設定ファイル
+# GLOW_CONFIG_HOME 環境変数(bashrc.d/environment.sh で設定)経由で参照させている
+
+# style name or JSON path (default "auto")
+style: "auto"
+# mouse support (TUI-mode only)
+mouse: false
+# use pager to display markdown
+pager: true
+# word-wrap at width
+width: 80
+# show all files, including hidden and ignored.
+all: false


### PR DESCRIPTION
## Issue

- #xx

## 対応内容

glow を常にページャーで表示したいという要望に対応する。

- `glow/glow.yml` を追加し、`pager: true` を設定(その他はデフォルト値)。
- glow は `GLOW_CONFIG_HOME` **直下**(`glow` サブディレクトリ無し)の `glow.yml` を設定ファイルとして参照する(`XDG_CONFIG_HOME` は `$XDG_CONFIG_HOME/glow/glow.yml` を見るのと異なる)。そのため `bashrc.d/environment.sh` で `GLOW_CONFIG_HOME` を dotfiles 内の `glow/` へ向け、設定を dotfiles で管理できるようにした(`GIT_CONFIG_GLOBAL` / `MYVIMRC` / `STARSHIP_CONFIG` と同じ発想)。
- graceful-degradation の制約に従い、`type glow` ガードの中で `export` している(glow 未インストール環境でもエラーにならない)。

補足: 環境変数だけで済ませたい場合は glow が viper の env prefix (`glow`) + `AutomaticEnv` を持つため `GLOW_PAGER=true` でもページャーを有効化できるが、要望どおり「設定ファイルを dotfiles 内に置いて参照させる」方式を採用した。

## テスト

- `npx prettier --check glow/glow.yml` → パス
- `npx cspell` → 指摘なし
- `bash -n bashrc.d/environment.sh` → 構文エラーなし

(shellcheck はローカル環境に未インストールのため未実行。CI の Format/Spell ワークフローで検証される想定。)

## 残作業

- 特になし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJz3cLew8N7pcVmPLfdFbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJz3cLew8N7pcVmPLfdFbS)_