### PR TITLE
Add msedit (Microsoft Edit) to nix package list

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -92,6 +92,7 @@
     "MANROFFOPT",
     "mattn",
     "mkcd",
+    "msedit",
     "MYVIMRC",
     "nathanaelkane",
     "nerdtree",

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -38,6 +38,7 @@
               jq
               less
               lv
+              msedit
               nkf
               ripgrep
               rustup


### PR DESCRIPTION
## Issue

-

## 対応内容

`nix/flake.nix` の `packages.<system>.default` に `msedit` (Microsoft Edit、実行コマンドは `edit`) を追加しました。あわせて `.cspell.json` の単語リストに `msedit` を追加しています。

## テスト

- `npx prettier --check "**/*.{json,md,yml}"`
- `npx cspell .`

## 残作業

- 特になし


---
_Generated by [Claude Code](https://claude.ai/code/session_011nsfxcJ56quhyA9h9FySS5)_