### PR TITLE
ci: bashrc.shのgraceful-degradationを検証するジョブを追加する

### DIFF
--- a/.github/workflows/graceful-degradation.yml
+++ b/.github/workflows/graceful-degradation.yml
@@ -15,6 +15,12 @@ jobs:
     strategy:
       matrix:
         container: ["rockylinux:9", "ubuntu:latest"]
+    # ubuntu:latestの/bin/shはdashであり、bash専用の`&>`リダイレクトが
+    # 意図通りに解釈されない(バックグラウンド実行+無関係なリダイレクトとして
+    # 誤解釈され、ifの条件が常にtrueになる)ため、bashを明示的に使う
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Set up
@@ -47,12 +53,12 @@ jobs:
 
       - name: bat が未導入のときは cat の alias が登録されないことを確認する(graceful-degradationの実効性確認)
         run: |
-          if type bat &>/dev/null; then
+          if type bat >/dev/null 2>&1; then
             echo "このジョブは bat が未導入であることを前提としています"
             exit 1
           fi
 
-          if bash -c 'source ./bashrc.sh; alias cat' &>/dev/null; then
+          if bash -c 'source ./bashrc.sh; alias cat' >/dev/null 2>&1; then
             echo "bat が未導入にもかかわらず cat の alias が登録されています"
             exit 1
           fi

--- a/.github/workflows/graceful-degradation.yml
+++ b/.github/workflows/graceful-degradation.yml
@@ -1,0 +1,62 @@
+name: Graceful degradation
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bashrc-without-nix:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      matrix:
+        container: ["rockylinux:9", "ubuntu:latest"]
+
+    steps:
+      - name: Set up
+        run: |
+          if [ "${{ matrix.container }}" = "rockylinux:9" ]; then
+            dnf install -y --allowerasing bash git
+          elif [ "${{ matrix.container }}" = "ubuntu:latest" ]; then
+            apt-get update && apt-get install -y bash git
+          fi
+
+      - uses: actions/checkout@v7
+
+      - name: bashrc.sh が Nix・ツール未導入でもエラーなく最後まで読み込まれることを確認する
+        run: |
+          set +e
+          stderr=$(bash -c 'source ./bashrc.sh' 2>&1 >/dev/null)
+          status=$?
+          set -e
+
+          if [ -n "${stderr}" ]; then
+            echo "bashrc.sh の source 中に標準エラー出力がありました:"
+            echo "${stderr}"
+            exit 1
+          fi
+
+          if [ "${status}" -ne 0 ]; then
+            echo "bashrc.sh の source が exit code ${status} で終了しました"
+            exit 1
+          fi
+
+      - name: bat が未導入のときは cat の alias が登録されないことを確認する(graceful-degradationの実効性確認)
+        run: |
+          if type bat &>/dev/null; then
+            echo "このジョブは bat が未導入であることを前提としています"
+            exit 1
+          fi
+
+          if bash -c 'source ./bashrc.sh; alias cat' &>/dev/null; then
+            echo "bat が未導入にもかかわらず cat の alias が登録されています"
+            exit 1
+          fi

--- a/.github/workflows/graceful-degradation.yml
+++ b/.github/workflows/graceful-degradation.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/bashrc.d/environment.sh
+++ b/bashrc.d/environment.sh
@@ -15,10 +15,21 @@ else
     # "\001"と"\002をつけることで、エスケープシーケンスの部分は文字数に数えられなくなる(っぽい)
     # PS1で直接変数を利用する場合は"\001"は"\["に、"\002"は"\]"に置き換え可能だが、
     # これらは関数内部で使うと動作しないため、"\001"と"\002"を使っている
-    _reset="\001$(tput sgr0)\002"
-    _red="\001$(tput setaf 1)\002"
-    _green="\001$(tput setaf 2)\002"
-    _blue="\001$(tput setaf 4)\002"
+    # TERMが未設定(例: CIコンテナのrunステップ)やdumbのときにtputを呼ぶと、
+    # `tput: No value for $TERM and no -T specified`のようなエラーが標準エラーに出る。
+    # bashrc.shは「ツール未導入でもエラーを出さずに最後まで読み込まれる」ことを制約としているため、
+    # 色付けが可能な端末のときだけtputで色を取得し、それ以外は色無しにフォールバックする。
+    if [[ -n "${TERM:-}" && "${TERM}" != "dumb" ]]; then
+        _reset="\001$(tput sgr0)\002"
+        _red="\001$(tput setaf 1)\002"
+        _green="\001$(tput setaf 2)\002"
+        _blue="\001$(tput setaf 4)\002"
+    else
+        _reset=""
+        _red=""
+        _green=""
+        _blue=""
+    fi
 
     function _color_by_exit_code() {
         local exit_code="${?}"


### PR DESCRIPTION
## Issue

- #164

## 対応内容

Nix・各種ツールが一切導入されていない環境でも `bashrc.sh` がエラーを出さずに最後まで読み込まれること(CLAUDE.mdが「最重要の制約」と位置づける graceful-degradation 設計)を、これまでCIで一度も検証していなかったため、新規ワークフロー `.github/workflows/graceful-degradation.yml` を追加した。

- `rockylinux:9` / `ubuntu:latest` の素のコンテナ(Nix・dotfiles由来のツール一切なし)で `bashrc.sh` を source し、標準エラー出力が空であること・exit code が 0 であることを確認する。
- `bat` が未導入の状態で `cat` の alias が登録されていないことも確認し、graceful-degradationのガード(`bashrc.d/aliases.sh` の `alias()` オーバーライド)が実際に効いていることを検証する。

**敵対的レビューで発覚した不具合の修正:** GitHub Actionsのコンテナ内 `run:` ステップは `TERM` が未設定になることが多く、その状態で `tput` を呼ぶと `tput: No value for $TERM and no -T specified` が標準エラーに出て、上記の「stderrが空であること」の検証が誤って失敗する(false-red)ことが判明した。`bashrc.d/environment.sh` の starship 未導入時のプロンプト設定処理を修正し、`TERM` が未設定または `dumb` のときは `tput` を呼ばずに色無しへフォールバックするようにした。これはこの制約自体をより堅牢にする修正でもある。

**concurrencyは追加しない:** 本リポジトリはpublicでGitHub-hostedランナーのActions分は無料枠が無制限のため節約メリットが無く、むしろ`cancel-in-progress`は素早く連続でpushした際に途中のコミットの実行結果を完走させずに打ち切ってしまい、どのコミットから壊れたかの追跡を妨げるため、追加を見送った。

## テスト

- `npx prettier --check` / `npx cspell .` / `shellcheck`(`nix run nixpkgs#shellcheck`)がいずれもクリーンであることを確認済み。
- ワークフロー自体はPRを開いた時点でCI上で実行される。

## 残作業

なし