### PR TITLE
ci: nix flake checkとnixfmtでの整形チェックを追加する

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -97,6 +97,7 @@
     "nathanaelkane",
     "nerdtree",
     "nixbld",
+    "nixfmt",
     "nixos",
     "nixpkgs",
     "nmap",

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,34 @@
+name: Nix
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# 同じブランチ/PRで新しい実行が始まったら、古い実行はキャンセルする
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    # 未認証のままだとflake.nixのnixpkgs取得時にGitHub APIのレート制限に引っかかることがあるため、認証する
+    env:
+      NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: nix flake check
+        run: nix flake check ./nix
+
+      - name: nixfmt --check
+        run: nix run nixpkgs#nixfmt -- --check nix/flake.nix

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,11 +5,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-# 同じブランチ/PRで新しい実行が始まったら、古い実行はキャンセルする
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 


### PR DESCRIPTION
## Issue

- #166

## 対応内容

`flake.nix` の評価が `install.sh` を通じた間接的なものに留まっており、`.nix` ファイルのフォーマットも prettier の対象外で未チェックだったため、`nix flake check` と `nixfmt` によるフォーマットチェックを行うCIワークフロー `.github/workflows/nix.yml` を追加した。

- `nix flake check ./nix`(flakeは `nix/` サブディレクトリにあるため対象を指定)
- `nix run nixpkgs#nixfmt -- --check nix/flake.nix`
  - 当初 `nixfmt-rfc-style` を使う想定だったが、このマシンで実際に実行したところ「`nixfmt-rfc-style` は `pkgs.nixfmt` と統合されたので `nixfmt` を使うべき」という非推奨警告が出たため、`nixfmt` を直接使うよう変更した。
- 既存の `main.yml` と同様に `NIX_CONFIG` でnixpkgs取得のレート制限を回避する。

**concurrencyは追加しない:** 本リポジトリはpublicでGitHub-hostedランナーのActions分は無料枠が無制限のため節約メリットが無く、むしろ`cancel-in-progress`は素早く連続でpushした際に途中のコミットの実行結果を完走させずに打ち切ってしまい、どのコミットから壊れたかの追跡を妨げるため、追加を見送った。

## テスト

**このマシンでNixが使えたため、CI上で初めて検証するのではなく、事前に手元で両コマンドを実際に実行して確認済み:**

- `nix flake check ./nix` → `all checks passed!`(exit 0)
- `nix run nixpkgs#nixfmt -- --check nix/flake.nix` → 差分なし(exit 0)、`flake.nix` は既に整形済みであることを確認

- `npx prettier --check` / `npx cspell .` もクリーン。

## 残作業

なし