### PR TITLE
ci: GitHub Actionsワークフローをハードニングする

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,13 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,10 +7,6 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,14 +5,25 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# デフォルトを最小権限にし、権限が必要なジョブでのみ個別に上書きする
+permissions:
+  contents: read
+
 jobs:
   shellscript:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Run the sh-checker
-        uses: luizm/action-sh-checker@master
+        uses: luizm/action-sh-checker@v0.10.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHELLCHECK_OPTS: --exclude=SC1090,SC1091,SC2046
@@ -21,6 +32,8 @@ jobs:
 
   prettier:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 # デフォルトを最小権限にし、権限が必要なジョブでのみ個別に上書きする
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,6 @@ on:
   schedule:
     - cron: "0 9 * * 5"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,13 @@ on:
   schedule:
     - cron: "0 9 * * 5"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   install-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -5,9 +5,20 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# デフォルトを最小権限にし、権限が必要なジョブでのみ個別に上書きする
+permissions:
+  contents: read
+
 jobs:
   spell:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -28,6 +39,8 @@ jobs:
 
   file-name:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 # デフォルトを最小権限にし、権限が必要なジョブでのみ個別に上書きする
 permissions:
   contents: read


### PR DESCRIPTION
## Issue

- #167

## 対応内容

既存の4ワークフロー(`main.yml` / `format.yml` / `spell.yml` / `docker-image.yml`)に対し、以下のハードニングを行った。挙動(ジョブのロジック)は変更していない。

1. **Actionのピン留め**: `format.yml` の `luizm/action-sh-checker` を moving target の `@master` から、実在する最新リリースタグ `@v0.10.0` へピン留めした。
2. **permissionsの最小権限化**: 各ワークフローにトップレベルで `contents: read` をデフォルトとして設定し、reviewdog/action-sh-checkerがPRへコメントを投稿するジョブ(`format.yml` の `shellscript`、`spell.yml` の `spell`)にのみジョブ単位で `pull-requests: write` を追加で付与した。それ以外のジョブ(`prettier`、`file-name`、`main.yml`、`docker-image.yml`)は `contents: read` のみ。

**concurrencyは追加しない:** 当初は同一ref上の古い実行をキャンセルする `concurrency` も追加していたが、本リポジトリはpublicでGitHub-hostedランナーのActions分は無料枠が無制限のため節約メリットが無く、むしろ`cancel-in-progress`は素早く連続でpushした際に途中のコミットの実行結果(特に`main.yml`のinstall→update→uninstallライフサイクル検証)を完走させずに打ち切ってしまい、どのコミットから壊れたかの追跡を妨げるため、追加を取りやめた。

## テスト

- `npx prettier --check` / `npx cspell .` がクリーンであることを確認済み。
- reviewdog/action-sh-checkerのコメント投稿に必要な `pull-requests: write` を落としていないことを確認済み(該当ジョブのみ明示的に付与)。

## 残作業

なし