### PR TITLE
refactor: git/.gitconfigをgit/gitconfigへリネームする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .bash_history
 vim/local/
-git/.gitconfig.local
+git/gitconfig.local

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
     "editor.formatOnType": false
   },
   "[properties]": {
-    // 今のところpropertiesファイルは.gitconfigのみで、.gitconfigにはフォーマッターがないので無効にしておく
+    // 今のところpropertiesファイルはgit/gitconfigのみで、gitconfigにはフォーマッターがないので無効にしておく
     "editor.formatOnSave": false
   },
   "editor.formatOnSave": true,

--- a/bashrc.d/environment.sh
+++ b/bashrc.d/environment.sh
@@ -174,7 +174,7 @@ if type zoxide &>/dev/null; then
 fi
 
 if type git &>/dev/null; then
-    export GIT_CONFIG_GLOBAL="${DOTFILES_DIRECTORY}/git/.gitconfig"
+    export GIT_CONFIG_GLOBAL="${DOTFILES_DIRECTORY}/git/gitconfig"
 fi
 
 if type glow &>/dev/null; then

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -40,4 +40,4 @@
 [include]
 	# リポジトリごとに設定を変えたい場合がある
 	# そのためリポジトリごとに設定ファイルを作成し、includeで読み込む
-	path = .gitconfig.local
+	path = gitconfig.local


### PR DESCRIPTION
## Issue

- なし(構成レビューで挙がった軽微な命名不統一の解消)

## 対応内容

`starship/starship.toml` / `tmux/tmux.conf` / `nix/nix.conf` など、ツール別ディレクトリに切り出した設定ファイルはディレクトリに入れた時点で先頭のドットを付けない命名にしているのに対し、`git/.gitconfig` だけドット付きのままで不統一だったため、`git/gitconfig` へリネームした。

- `git mv git/.gitconfig git/gitconfig` で履歴を保持したままリネーム。
- `bashrc.d/environment.sh` の `GIT_CONFIG_GLOBAL` 参照を更新。
- `.vscode/settings.json` のコメント中の言及を更新。
- リポジトリごとのローカル上書き用ファイル `.gitconfig.local`(`.gitignore` 対象で本リポジトリには含まれない、各マシン固有のGPG/SSH署名設定などを書く場所)も同様に `gitconfig.local` へ名前を揃え、`.gitignore` と `git/gitconfig` の `[include] path` の参照を更新した。

`GIT_CONFIG_GLOBAL` はどんなファイル名でも動作するため、git自体の機能的な変更はない。

## テスト

- `npx prettier --check` / `npx cspell .` / `shellcheck`(`nix run nixpkgs#shellcheck`)がいずれもクリーンであることを確認済み。

## 残作業

**マージ後、このリポジトリを使っている各マシンで、ローカルの `git/.gitconfig.local` を `git/gitconfig.local` へ手動でリネームする必要がある。** リネームしないと `[include] path = gitconfig.local` が見つからずサイレントに無視され、GPG/SSH署名鍵などのマシン固有設定が反映されなくなる(エラーは出ない)。このファイルは `.gitignore` 対象のため、このPRのマージだけでは自動的に追従できない。