### PR TITLE
docs: PR作成時にラベルを付与する運用をCLAUDE.mdに明記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 コミットする前には必ず `npx cspell .` を実行し、指摘があれば解消してからコミットすること。
 cspellのチェックにはよく引っかかるため。
 
+PRを作成したら、内容に応じて既存ラベル(`bug`/`enhancement`/`documentation` など、
+`gh label list` で確認できるもの)を必ず付与すること。過去の慣例では `fix:` 系は `bug`、
+`feat:`/`add:`/`update:`/`refactor:`/`chore:`/`ci:` 系は `enhancement`、ドキュメントのみの
+変更は `documentation` を付けている。
+
 Lint(GitHub ActionsのFormat/Spellワークフローと同じもの):
 
 ```bash


### PR DESCRIPTION
## Summary
- PR #147以降、PR自体へのラベル付与が漏れていた(#147〜#171 の19件に今回まとめて付与済み)
- 再発防止のため、作業フローにラベル付与の慣例を明記した
  - `fix:` 系 → `bug`
  - `feat:`/`add:`/`update:`/`refactor:`/`chore:`/`ci:` 系 → `enhancement`
  - ドキュメントのみの変更 → `documentation`

## Test plan
- [x] `npx cspell .`
- [x] `npx prettier --check "**/*.{json,md,yml}"`