### PR TITLE
fix: Nix 2.34のnix profile CLI仕様変更に追従する

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -64,6 +64,7 @@
     "glibc",
     "gpgsign",
     "groupinstall",
+    "gsub",
     "guicursor",
     "guix",
     "haxe",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,14 @@ npx cspell .
 ### パッケージ管理: nix/flake.nix + `nix profile`
 
 `nix/flake.nix` の `packages.<system>.default` に全ツールを1つの `buildEnv` として宣言している。
-`install.sh` は `nix profile install`(初回)/`nix profile upgrade '.*'`(2回目以降、
-`nix profile list` に自分の flake パス文字列が含まれるかで判定)を使い分けて反映する。
+`install.sh` は `nix profile install`(初回)/`nix profile upgrade`(2回目以降)を使い分けて反映する。
 ツールの追加・削除は `nix/flake.nix` の `paths` を編集するだけでよい。
+
+Nix 2.34 では `nix profile` の各サブコマンドの位置引数が正規表現ではなく**要素名**として解釈される
+(全要素を対象にするには `--all`、正規表現を使うには `--regex`)。そのため `install.sh`・`uninstall.sh`
+はどちらも `nix profile list` の出力から自分が入れた要素の名前を取り出して渡している。
+`nix profile list` はパイプに繋いでも色を付けるため、ANSIエスケープを除去してから解析する必要がある。
+`--all` は利用者が自分で入れた無関係なパッケージまで更新してしまうため使わない。
 
 Nix自体の設定(`nix.conf`)も `flake.nix`/`flake.lock` と同じく `nix/nix.conf` としてdotfiles内で
 管理し、`NIX_USER_CONF_FILES` 環境変数(`GIT_CONFIG_GLOBAL`や`MYVIMRC`と同じ発想)で参照させている。

--- a/install.sh
+++ b/install.sh
@@ -51,8 +51,42 @@ fi
 
 ##
 # @brief nix/flake.nix に記載しているコマンド一式をインストールする(既にインストール済みなら最新化する)
-if nix profile list 2>/dev/null | grep -qF "${SCRIPT_DIRECTORY}"; then
-    nix profile upgrade '.*'
+# Nix 2.34 では nix profile の各サブコマンドの位置引数が正規表現ではなく「要素名」として
+# 解釈されるようになったため、要素名とflake URLを nix profile list から取り出して扱う
+# nix profile list はパイプに繋いでも(NIX_USER_CONF_FILESやNO_COLORに関わらず)色を付けるため、
+# ANSIエスケープを除去してから解析する
+DOTFILES_PROFILE_ELEMENTS="$(nix profile list 2>/dev/null | awk -v dir="${SCRIPT_DIRECTORY}" '
+    { gsub(/\033\[[0-9;]*m/, "") }
+    /^Name:/ { name = $2 }
+    /^Original flake URL:/ && index($0, dir) { print name, $4 }
+')"
+
+# 更新すべき要素と、入れ直しが必要な古いプロファイルを仕分ける
+CURRENT_ELEMENTS=""
+LEGACY_ELEMENTS=""
+while read -r ELEMENT_NAME ELEMENT_URL; do
+    [[ -z "${ELEMENT_NAME}" ]] && continue
+
+    if [[ "${ELEMENT_URL}" == *"?dir=nix"* ]]; then
+        CURRENT_ELEMENTS+="${ELEMENT_NAME} "
+    else
+        # flake.nix をリポジトリルートから nix/ へ移動する前にインストールしたプロファイルは
+        # 現存しないルートの flake.nix を参照しており upgrade できないため、削除して入れ直す
+        LEGACY_ELEMENTS+="${ELEMENT_NAME} "
+    fi
+done <<<"${DOTFILES_PROFILE_ELEMENTS}"
+
+if [[ -n "${LEGACY_ELEMENTS}" ]]; then
+    # 要素名は空白を含まないため、意図的に単語分割させて複数要素を渡す
+    # shellcheck disable=SC2086
+    nix profile remove ${LEGACY_ELEMENTS}
+fi
+
+if [[ -n "${CURRENT_ELEMENTS}" ]]; then
+    # --all では利用者が自分で `nix profile install` した無関係なパッケージまで更新して
+    # しまうため、このdotfilesが入れた要素だけを名前で指定して更新する
+    # shellcheck disable=SC2086
+    nix profile upgrade ${CURRENT_ELEMENTS}
 else
     nix profile install "${SCRIPT_DIRECTORY}/nix#default"
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,8 +12,19 @@ export NIX_USER_CONF_FILES="${SCRIPT_DIRECTORY}/nix/nix.conf"
 [[ -r /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]] && source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 
 if type nix &>/dev/null; then
-    if nix profile list 2>/dev/null | grep -qF "${SCRIPT_DIRECTORY}"; then
-        nix profile remove "${SCRIPT_DIRECTORY}/nix#default" || true
+    # Nix 2.34 では nix profile remove の位置引数が flake URL ではなく「要素名」として
+    # 解釈されるようになったため、要素名を nix profile list から取り出して渡す
+    # nix profile list はパイプに繋いでも色を付けるため、ANSIエスケープを除去してから解析する
+    DOTFILES_PROFILE_ELEMENTS="$(nix profile list 2>/dev/null | awk -v dir="${SCRIPT_DIRECTORY}" '
+        { gsub(/\033\[[0-9;]*m/, "") }
+        /^Name:/ { name = $2 }
+        /^Original flake URL:/ && index($0, dir) { print name }
+    ')"
+
+    if [[ -n "${DOTFILES_PROFILE_ELEMENTS}" ]]; then
+        # 要素名は空白を含まないため、意図的に単語分割させて複数要素を渡す
+        # shellcheck disable=SC2086
+        nix profile remove ${DOTFILES_PROFILE_ELEMENTS} || true
     fi
 fi
 


### PR DESCRIPTION
## 概要

Nix 2.34 では `nix profile` の位置引数が正規表現ではなく**要素名**として解釈されるようになり、`install.sh` の更新処理と `uninstall.sh` の削除処理が動作しなくなっていました。

## 問題

### 1. `install.sh`: 更新が一切行われていない

```console
$ ./install.sh
warning: Package name '.*' does not match any packages in the profile.
warning: No packages to upgrade. Use 'nix profile list' to see the current profile.
```

`nix profile upgrade '.*'` の `'.*'` が要素名として扱われ、何にもマッチしていませんでした。正規表現を使うには `--regex`、全要素を対象にするには `--all` が必要です。

```console
$ nix profile upgrade --help
  · Upgrade all packages ...:   nix profile upgrade --all
  · Upgrade all packages that include 'vim' in their name:
                                nix profile upgrade --regex '.*vim.*'
```

### 2. `uninstall.sh`: 削除できていない

`nix profile remove "${SCRIPT_DIRECTORY}/nix#default"` も同様に flake URL が要素名として扱われずマッチしません。`|| true` と、その後の `rm -rf /nix` によって表面化していませんでした。

### 3. #157 以前のプロファイルは `upgrade` できない

1 の影響で、手元の環境では #147 の rev のままプロファイルが固定されていました。その後 #157 で `flake.nix` をリポジトリルートから `nix/` へ移動しているため、このプロファイルは現存しないルートの `flake.nix` を参照しており、更新できません。

```console
$ nix flake metadata "git+file:///path/to/dotfiles"
error: Path 'flake.nix' does not exist in Git repository "/path/to/dotfiles".
```

## 変更内容

`nix profile list` の出力から要素名と flake URL を取り出して渡すようにしました。`nix profile list` はパイプに繋いでも色を付けるため、ANSI エスケープを除去してから解析しています(`NO_COLOR=1` でも色は消えませんでした)。

- `install.sh`: 要素の flake URL に `?dir=nix` が含まれるかで「現行のプロファイル」と「#157 以前の古いプロファイル」を仕分け、古いものは削除してから入れ直す。現行のものは要素名を指定して更新する
- `uninstall.sh`: 要素名を取り出して `nix profile remove` に渡す
- `CLAUDE.md`: `nix profile upgrade '.*'` を前提にした記述を更新

更新に `--all` を使わないのは、利用者が自分で `nix profile install` した無関係なパッケージまで更新してしまうためです。実際 `--all` では以下の警告も出ます。

```console
warning: Found package 'nix', but it was not added from a flake, so it can't be checked for upgrades!
```

## 動作確認

### 要素の仕分けと実行されるコマンド

4パターンのフィクスチャで確認しました。

| フィクスチャ | 実行されるコマンド |
| --- | --- |
| 現行プロファイルのみ | `upgrade[nix-1]` |
| #157 以前のみ | `remove[dotfiles]` + `install` |
| 両方 | `remove[dotfiles]` + `upgrade[nix-1]` |
| 未インストール | `install` |

### 実プロファイルに対する動作

`install.sh` の当該ブロックを実際のプロファイルに対して実行し、更新できることを確認しました。

```console
[branch] upgrade
upgrading 'packages.x86_64-linux.default' from flake 'git+file:///path/to/dotfiles?dir=nix'
```

### `uninstall.sh` の要素名抽出

スクラッチプロファイルに #157 以前と同じ形式の要素を作り、抽出した名前で実際に削除できることを確認しました。

```console
抽出した要素名: [dotfiles]
removing 'git+file:///path/to/dotfiles?rev=4312c9c...#packages.x86_64-linux.default'
removed 1 packages, kept 0 packages
--- 残り要素数 ---
0
```

install → update → uninstall のライフサイクル全体は CI で検証されます。

## Lint

- `shellcheck --exclude=SC1090,SC1091,SC2046 *.sh bashrc.d/*.sh`: パス
- `npx prettier --check "**/*.{json,md,yml}"`: パス
- `npx cspell .`: パス(`gsub` を辞書に追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
