### PR TITLE
fix: rustup-initが存在せずRustのセットアップが行われない問題を修正する

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,16 @@ fi
 
 ##
 # @brief Rust の環境をセットアップする
-if type rustup-init &>/dev/null; then
-    rustup-init -y
+# nixpkgsのrustupパッケージはrustup-initを提供せず、rustupとそのshim(cargo, rustcなど)のみを
+# 提供するため、rustup-initではなくrustup自体でデフォルトツールチェインを導入する
+# shimはツールチェインが入っていないと動かないため、この処理が必要になる
+if type rustup &>/dev/null; then
+    # デフォルトツールチェインが未設定のときだけ導入する
+    # 設定済みなら `rustup default` はネットワークアクセス無しに即座に終わるため、
+    # install.sh を再実行したときの待ち時間が増えない
+    if ! rustup default &>/dev/null; then
+        rustup default stable
+    fi
 else
     echo "Can not setup Rust environment." >&2
 fi


### PR DESCRIPTION
## 問題

`install.sh` を実行すると、毎回 `Can not setup Rust environment.` が出力されます。

```console
$ ./install.sh
warning: Package name '.*' does not match any packages in the profile.
warning: No packages to upgrade. Use 'nix profile list' to see the current profile.
Can not setup Rust environment.
```

nixpkgs の `rustup` パッケージは `rustup-init` を提供しておらず、`rustup` とその shim のみを提供しているためです。

```console
$ type rustup-init
bash: type: rustup-init: 見つかりません

$ ls "$(dirname "$(readlink -f "$(command -v rustup)")")"
cargo  cargo-clippy  cargo-fmt  cargo-miri  clippy-driver  rls  rust-analyzer
rust-gdb  rust-gdbgui  rust-lldb  rustc  rustdoc  rustfmt  rustup
```

そのため `install.sh` の `if type rustup-init` が常に偽になり、Rust のセットアップが一度も行われていませんでした。`cargo` や `rustc` は shim なので、ツールチェインが入っていないと動きません。

## 変更内容

`rustup-init` の代わりに `rustup` 自体でデフォルトツールチェインを導入するようにしました。

デフォルトツールチェインが未設定のときだけ `rustup default stable` を実行します。設定済みなら `rustup default` はネットワークアクセス無しに即座に終わるため、`install.sh` を再実行したときの待ち時間は増えません。

```console
$ time rustup default >/dev/null 2>&1
real	0m0.010s
```

## 動作確認

`RUSTUP_HOME` を空ディレクトリに向けて、未設定・設定済みそれぞれの判定を確認しました。

| 状態 | `rustup default` の出力 | 終了コード | 判定 |
| --- | --- | --- | --- |
| 未設定 | `error: no default toolchain is configured` | 1 | `rustup default stable` を実行 |
| 設定済み | `stable-x86_64-unknown-linux-gnu (default)` | 0 | 何もしない |

## 備考

この修正により、これまで実質スキップされていたツールチェインの導入が実際に走るようになります。未導入の環境(CI を含む)では初回のみダウンロード時間が増えます。

## Lint

- `shellcheck --exclude=SC1090,SC1091,SC2046 *.sh bashrc.d/*.sh`: パス
- `npx prettier --check "**/*.{json,md,yml}"`: パス
- `npx cspell .`: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)