### PR TITLE
feat: nvmをnixで管理する

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -43,6 +43,7 @@
     "dirspell",
     "DIRTRIM",
     "diskutil",
+    "dont",
     "dotfiles",
     "dotglob",
     "dscl",

--- a/bashrc.sh
+++ b/bashrc.sh
@@ -29,6 +29,17 @@ if type fzf &>/dev/null; then
     eval "$(fzf --bash)"
 fi
 
+# nvmはコマンドとしてではなくシェル関数として提供されるため、`type nvm`ではなく
+# nvm.shの有無で導入判定する
+if [[ -r ~/.nix-profile/share/nvm/nvm.sh ]]; then
+    export NVM_DIR="${HOME}/.nvm"
+    source ~/.nix-profile/share/nvm/nvm.sh
+
+    if [[ -r ~/.nix-profile/share/nvm/bash_completion ]]; then
+        source ~/.nix-profile/share/nvm/bash_completion
+    fi
+fi
+
 if type git &>/dev/null; then
     # gitの補完はnix profileでインストールした場合は他の補完を有効にするときに一緒に有効になる
     # そのため、ここではnix profileのgitの補完は有効にしない

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -11,7 +11,11 @@
   };
 
   outputs =
-    { self, nixpkgs, nvm-src }:
+    {
+      self,
+      nixpkgs,
+      nvm-src,
+    }:
     let
       forAllSystems =
         f:

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -3,8 +3,15 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
+  # nvmはnixpkgsにパッケージが存在しないため、本体のリポジトリから直接取得して
+  # 自前でビルドする
+  inputs.nvm-src = {
+    url = "github:nvm-sh/nvm/v0.40.6";
+    flake = false;
+  };
+
   outputs =
-    { self, nixpkgs }:
+    { self, nixpkgs, nvm-src }:
     let
       forAllSystems =
         f:
@@ -40,6 +47,17 @@
               lv
               msedit
               nkf
+              # nvmはnixpkgsにパッケージが存在しないため、nvm-src(nvm-sh/nvm)から自前でビルドする
+              (stdenvNoCC.mkDerivation {
+                pname = "nvm";
+                version = "0.40.6";
+                src = nvm-src;
+                dontBuild = true;
+                installPhase = ''
+                  mkdir -p "$out/share/nvm"
+                  cp nvm.sh nvm-exec bash_completion "$out/share/nvm/"
+                '';
+              })
               ripgrep
               rustup
               sourceHighlight


### PR DESCRIPTION
## Issue

- なし(小規模な対応のため)

## 対応内容

nvmをnixで管理できるようにしました。

nvm(nvm-sh/nvm)はnixpkgsに公式パッケージが存在しないため(nvmがNode.jsを実行時に動的取得する仕組みのため、Nixの宣言的な思想と相性が悪いことが理由と思われます)、`nix/flake.nix`にnvm本体のリポジトリを`nvm-src`というflake inputとして追加し、`nvm.sh`・`nvm-exec`・`bash_completion`のみを`$out/share/nvm`に配置する自前のderivationとしてパッケージ化しました。

`bashrc.sh`側は、このリポジトリの「Nixが導入されていなくてもエラーなく最後まで読み込める」というgraceful-degradation方針に沿って、`~/.nix-profile/share/nvm/nvm.sh`の有無を見て`NVM_DIR`のexportとnvm本体・補完スクリプトのsourceを行うようにしています。

なお、Node.jsのバージョン自体(`nvm install`で入るもの)はこれまで通りnvmが`~/.nvm`配下にダウンロードする形のままで、Nix管理下には置いていません(nvm自体の使い勝手を変えないため)。

## テスト

- `npx cspell .`: 追加した`dontBuild`を`.cspell.json`の`words`に追加した上で0件
- `shellcheck --exclude=SC1090,SC1091,SC2046 *.sh bashrc.d/*.sh`: 0件
- `npx prettier --check "**/*.{json,md,yml}"`: 差分なし
- `bash -n bashrc.sh`: 構文エラーなし
- `nix flake check` / `nixfmt --check`はNixが使えない環境だったため未実施です。CI(Nixワークフロー)での確認をお願いします。

## 残作業

- `nix/flake.lock`は今回新しく追加した`nvm-src` inputの分を含めて未更新です。`nix flake check`やCIでの`nix profile install`実行時にNixが自動でlockエントリを補完しますが、リポジトリにコミットされている`nix/flake.lock`自体は既存の週次ワークフロー(Update flake.lock)で更新されるまで反映されない状態です。

---
_Generated by [Claude Code](https://claude.ai/code/session_013U4nQbmXZzUwhDcCjhmty8)_